### PR TITLE
Decouple Storage from RecipeManager

### DIFF
--- a/src/main/java/decodex/Decodex.java
+++ b/src/main/java/decodex/Decodex.java
@@ -48,7 +48,7 @@ public class Decodex {
         parser = new Parser();
         ui = new Ui();
         storage = new Storage();
-        recipeManager = new RecipeManager(storage);
+        recipeManager = new RecipeManager();
         try {
             loadSavedRecipes();
         } catch (IOException err) {
@@ -82,7 +82,7 @@ public class Decodex {
             try {
                 command = parser.parseCommand(userInput);
                 assert command != null : "Command should not be null";
-                command.run(dataManager, moduleManager, ui, recipeManager);
+                command.run(dataManager, moduleManager, ui, recipeManager, storage);
             } catch (ParserException | CommandException | ModuleManagerException | DataManagerException
                     | ModuleException | RecipeException | RecipeManagerException | IOException err) {
                 ui.printError(err);

--- a/src/main/java/decodex/commands/Command.java
+++ b/src/main/java/decodex/commands/Command.java
@@ -9,6 +9,7 @@ import decodex.data.exception.RecipeManagerException;
 import decodex.data.exception.ModuleManagerException;
 import decodex.modules.ModuleManager;
 import decodex.recipes.RecipeManager;
+import decodex.storage.Storage;
 import decodex.ui.Ui;
 import java.io.IOException;
 
@@ -20,7 +21,8 @@ public abstract class Command {
     public Command() {
     }
 
-    public abstract void run(DataManager dataManager, ModuleManager moduleManager, Ui ui, RecipeManager recipeManager)
+    public abstract void run(DataManager dataManager, ModuleManager moduleManager, Ui ui, RecipeManager recipeManager,
+            Storage storage)
             throws CommandException, ModuleManagerException, DataManagerException, ModuleException, RecipeException,
             RecipeManagerException, IOException;
 }

--- a/src/main/java/decodex/commands/ExitCommand.java
+++ b/src/main/java/decodex/commands/ExitCommand.java
@@ -3,6 +3,7 @@ package decodex.commands;
 import decodex.data.DataManager;
 import decodex.modules.ModuleManager;
 import decodex.recipes.RecipeManager;
+import decodex.storage.Storage;
 import decodex.ui.Ui;
 
 public class ExitCommand extends Command {
@@ -16,7 +17,8 @@ public class ExitCommand extends Command {
     }
 
     @Override
-    public void run(DataManager dataManager, ModuleManager moduleManager, Ui ui, RecipeManager recipeManager) {
+    public void run(DataManager dataManager, ModuleManager moduleManager, Ui ui, RecipeManager recipeManager,
+            Storage storage) {
         ui.printGoodbye();
     }
 }

--- a/src/main/java/decodex/commands/HelpCommand.java
+++ b/src/main/java/decodex/commands/HelpCommand.java
@@ -10,6 +10,7 @@ import decodex.commands.recipe.RecipeSelectCommand;
 import decodex.data.DataManager;
 import decodex.modules.ModuleManager;
 import decodex.recipes.RecipeManager;
+import decodex.storage.Storage;
 import decodex.ui.Ui;
 
 // @@author rizemon
@@ -42,7 +43,8 @@ public class HelpCommand extends Command {
     }
 
     @Override
-    public void run(DataManager dataManager, ModuleManager moduleManager, Ui ui, RecipeManager recipeManager) {
+    public void run(DataManager dataManager, ModuleManager moduleManager, Ui ui, RecipeManager recipeManager,
+            Storage storage) {
         ui.printCommandHelp(BASIC_COMMAND_HELP_MESSAGES, RECIPE_COMMAND_HELP_MESSAGES);
     }
 }

--- a/src/main/java/decodex/commands/InputCommand.java
+++ b/src/main/java/decodex/commands/InputCommand.java
@@ -5,6 +5,7 @@ import decodex.data.DataManager;
 import decodex.data.exception.CommandException;
 import decodex.modules.ModuleManager;
 import decodex.recipes.RecipeManager;
+import decodex.storage.Storage;
 import decodex.ui.Ui;
 import decodex.ui.messages.ErrorMessages;
 
@@ -23,7 +24,8 @@ public class InputCommand extends Command {
     }
 
     @Override
-    public void run(DataManager dataManager, ModuleManager moduleManager, Ui ui, RecipeManager recipeManager)
+    public void run(DataManager dataManager, ModuleManager moduleManager, Ui ui, RecipeManager recipeManager,
+            Storage storage)
             throws CommandException {
         if (dataString.isEmpty()) {
             throw new CommandException(ErrorMessages.MISSING_ARGUMENT);

--- a/src/main/java/decodex/commands/ListCommand.java
+++ b/src/main/java/decodex/commands/ListCommand.java
@@ -4,6 +4,7 @@ import decodex.data.DataManager;
 import decodex.data.exception.CommandException;
 import decodex.modules.ModuleManager;
 import decodex.recipes.RecipeManager;
+import decodex.storage.Storage;
 import decodex.ui.Ui;
 import decodex.ui.messages.ErrorMessages;
 
@@ -27,7 +28,8 @@ public class ListCommand extends Command {
     }
 
     @Override
-    public void run(DataManager dataManager, ModuleManager moduleManager, Ui ui, RecipeManager recipeManager)
+    public void run(DataManager dataManager, ModuleManager moduleManager, Ui ui, RecipeManager recipeManager,
+            Storage storage)
             throws CommandException {
         boolean isPrintModuleList = listCategory == null || listCategory.equals(LIST_CATEGORY_MODULES);
         boolean isPrintRecipeList = listCategory == null || listCategory.equals(LIST_CATEGORY_RECIPE);

--- a/src/main/java/decodex/commands/ResetCommand.java
+++ b/src/main/java/decodex/commands/ResetCommand.java
@@ -3,6 +3,7 @@ package decodex.commands;
 import decodex.data.DataManager;
 import decodex.modules.ModuleManager;
 import decodex.recipes.RecipeManager;
+import decodex.storage.Storage;
 import decodex.ui.Ui;
 import decodex.ui.messages.RegularMessages;
 
@@ -18,7 +19,8 @@ public class ResetCommand extends Command {
     }
 
     @Override
-    public void run(DataManager dataManager, ModuleManager moduleManager, Ui ui, RecipeManager recipeManager) {
+    public void run(DataManager dataManager, ModuleManager moduleManager, Ui ui, RecipeManager recipeManager,
+            Storage storage) {
         dataManager.resetToOriginalData();
         ui.printSuccess(RegularMessages.REVERTED_ALL_CHANGES);
     }

--- a/src/main/java/decodex/commands/SelectCommand.java
+++ b/src/main/java/decodex/commands/SelectCommand.java
@@ -12,6 +12,7 @@ import decodex.modules.Module;
 import decodex.modules.ModuleManager;
 import decodex.recipes.Recipe;
 import decodex.recipes.RecipeManager;
+import decodex.storage.Storage;
 import decodex.ui.Ui;
 import decodex.ui.messages.ErrorMessages;
 
@@ -36,7 +37,8 @@ public class SelectCommand extends Command {
     }
 
     @Override
-    public void run(DataManager dataManager, ModuleManager moduleManager, Ui ui, RecipeManager recipeManager)
+    public void run(DataManager dataManager, ModuleManager moduleManager, Ui ui, RecipeManager recipeManager,
+            Storage storage)
             throws ModuleManagerException, CommandException, DataManagerException, ModuleException, RecipeException,
             RecipeManagerException {
         assert selectCategory != null : "selectCategory should not be null";

--- a/src/main/java/decodex/commands/recipe/RecipeDeleteCommand.java
+++ b/src/main/java/decodex/commands/recipe/RecipeDeleteCommand.java
@@ -7,6 +7,7 @@ import decodex.data.exception.ModuleException;
 import decodex.data.exception.RecipeManagerException;
 import decodex.modules.ModuleManager;
 import decodex.recipes.RecipeManager;
+import decodex.storage.Storage;
 import decodex.ui.Ui;
 import decodex.ui.messages.ErrorMessages;
 import java.io.IOException;
@@ -25,13 +26,19 @@ public class RecipeDeleteCommand extends Command {
     }
 
     @Override
-    public void run(DataManager dataManager, ModuleManager moduleManager, Ui ui, RecipeManager recipeManager)
+    public void run(DataManager dataManager, ModuleManager moduleManager, Ui ui, RecipeManager recipeManager,
+            Storage storage)
             throws CommandException, ModuleException, RecipeManagerException, IOException {
         if (recipeName.isBlank()) {
             throw new CommandException(ErrorMessages.MISSING_RECIPE_NAME);
         }
 
         recipeManager.removeRecipe(recipeName);
+        try {
+            storage.deleteRecipeFile(recipeName);
+        } catch (IOException err) {
+            ui.printError(err);
+        }
         ui.printRecipeDeleted(recipeName);
     }
 }

--- a/src/main/java/decodex/commands/recipe/RecipeListCommand.java
+++ b/src/main/java/decodex/commands/recipe/RecipeListCommand.java
@@ -9,6 +9,7 @@ import decodex.modules.Module;
 import decodex.modules.ModuleManager;
 import decodex.recipes.Recipe;
 import decodex.recipes.RecipeManager;
+import decodex.storage.Storage;
 import decodex.ui.Ui;
 import decodex.ui.messages.RegularMessages;
 import java.util.ArrayList;
@@ -28,7 +29,8 @@ public class RecipeListCommand extends Command {
     }
 
     @Override
-    public void run(DataManager dataManager, ModuleManager moduleManager, Ui ui, RecipeManager recipeManager)
+    public void run(DataManager dataManager, ModuleManager moduleManager, Ui ui, RecipeManager recipeManager,
+            Storage storage)
             throws CommandException, ModuleException, RecipeManagerException {
         Recipe recipe;
 

--- a/src/main/java/decodex/commands/recipe/RecipeNewCommand.java
+++ b/src/main/java/decodex/commands/recipe/RecipeNewCommand.java
@@ -9,6 +9,7 @@ import decodex.data.exception.RecipeManagerException;
 import decodex.modules.ModuleManager;
 import decodex.recipes.Recipe;
 import decodex.recipes.RecipeManager;
+import decodex.storage.Storage;
 import decodex.ui.Ui;
 import decodex.ui.messages.ErrorMessages;
 import java.io.IOException;
@@ -27,8 +28,9 @@ public class RecipeNewCommand extends Command {
     }
 
     @Override
-    public void run(DataManager dataManager, ModuleManager moduleManager, Ui ui, RecipeManager recipeManager)
-            throws CommandException, ModuleException, RecipeException, RecipeManagerException, IOException {
+    public void run(DataManager dataManager, ModuleManager moduleManager, Ui ui, RecipeManager recipeManager,
+            Storage storage)
+            throws CommandException, ModuleException, RecipeException, RecipeManagerException {
         if (recipeName.isBlank()) {
             throw new CommandException(ErrorMessages.MISSING_RECIPE_NAME);
         }
@@ -36,6 +38,11 @@ public class RecipeNewCommand extends Command {
         Recipe recipe = new Recipe(recipeName);
 
         recipeManager.addRecipe(recipe);
+        try {
+            storage.saveRecipeToFile(recipe);
+        } catch (IOException err) {
+            ui.printError(err);
+        }
         recipeManager.selectRecipeForEditing(recipeName);
 
         ui.printNewRecipeCreated(recipe.getName());

--- a/src/main/java/decodex/commands/recipe/RecipePopCommand.java
+++ b/src/main/java/decodex/commands/recipe/RecipePopCommand.java
@@ -8,6 +8,7 @@ import decodex.modules.Module;
 import decodex.modules.ModuleManager;
 import decodex.recipes.Recipe;
 import decodex.recipes.RecipeManager;
+import decodex.storage.Storage;
 import decodex.ui.Ui;
 import java.io.IOException;
 
@@ -23,10 +24,16 @@ public class RecipePopCommand extends Command {
     }
 
     @Override
-    public void run(DataManager dataManager, ModuleManager moduleManager, Ui ui, RecipeManager recipeManager)
+    public void run(DataManager dataManager, ModuleManager moduleManager, Ui ui, RecipeManager recipeManager,
+            Storage storage)
             throws RecipeException, RecipeManagerException, IOException {
         Module module = recipeManager.popModuleFromEditedRecipe();
         Recipe editingRecipe = recipeManager.getEditingRecipe();
+        try {
+            storage.saveRecipeToFile(editingRecipe);
+        } catch (IOException err) {
+            ui.printError(err);
+        }
         ui.printModuleRemovedFromRecipe(module.getName(), editingRecipe.getName());
     }
 }

--- a/src/main/java/decodex/commands/recipe/RecipePushCommand.java
+++ b/src/main/java/decodex/commands/recipe/RecipePushCommand.java
@@ -10,6 +10,7 @@ import decodex.modules.Module;
 import decodex.modules.ModuleManager;
 import decodex.recipes.Recipe;
 import decodex.recipes.RecipeManager;
+import decodex.storage.Storage;
 import decodex.ui.Ui;
 import decodex.ui.messages.ErrorMessages;
 import java.io.IOException;
@@ -31,7 +32,8 @@ public class RecipePushCommand extends Command {
     }
 
     @Override
-    public void run(DataManager dataManager, ModuleManager moduleManager, Ui ui, RecipeManager recipeManager)
+    public void run(DataManager dataManager, ModuleManager moduleManager, Ui ui, RecipeManager recipeManager,
+            Storage storage)
             throws CommandException, ModuleManagerException, ModuleException, RecipeManagerException, IOException {
         if (moduleName.isBlank()) {
             throw new CommandException(ErrorMessages.MISSING_MODULE_NAME);
@@ -40,6 +42,11 @@ public class RecipePushCommand extends Command {
         Module module = moduleManager.selectModule(moduleName, parameters);
         Recipe editingRecipe =  recipeManager.getEditingRecipe();
         recipeManager.pushModuleIntoEditedRecipe(module);
+        try {
+            storage.saveRecipeToFile(editingRecipe);
+        } catch (IOException err) {
+            ui.printError(err);
+        }
         ui.printModuleAddedToRecipe(module.getName(),  editingRecipe.getName());
     }
 }

--- a/src/main/java/decodex/commands/recipe/RecipeResetCommand.java
+++ b/src/main/java/decodex/commands/recipe/RecipeResetCommand.java
@@ -6,6 +6,7 @@ import decodex.data.exception.RecipeManagerException;
 import decodex.modules.ModuleManager;
 import decodex.recipes.Recipe;
 import decodex.recipes.RecipeManager;
+import decodex.storage.Storage;
 import decodex.ui.Ui;
 import java.io.IOException;
 
@@ -21,10 +22,16 @@ public class RecipeResetCommand extends Command {
     }
 
     @Override
-    public void run(DataManager dataManager, ModuleManager moduleManager, Ui ui, RecipeManager recipeManager)
+    public void run(DataManager dataManager, ModuleManager moduleManager, Ui ui, RecipeManager recipeManager,
+            Storage storage)
             throws RecipeManagerException, IOException {
         Recipe editingRecipe = recipeManager.getEditingRecipe();
         recipeManager.resetEditedRecipe();
+        try {
+            storage.saveRecipeToFile(editingRecipe);
+        } catch (IOException err) {
+            ui.printError(err);
+        }
         ui.printRecipeReset(editingRecipe.getName());
     }
 }

--- a/src/main/java/decodex/commands/recipe/RecipeSelectCommand.java
+++ b/src/main/java/decodex/commands/recipe/RecipeSelectCommand.java
@@ -6,6 +6,7 @@ import decodex.data.exception.CommandException;
 import decodex.data.exception.RecipeManagerException;
 import decodex.modules.ModuleManager;
 import decodex.recipes.RecipeManager;
+import decodex.storage.Storage;
 import decodex.ui.Ui;
 import decodex.ui.messages.ErrorMessages;
 
@@ -24,7 +25,8 @@ public class RecipeSelectCommand extends Command {
     }
 
     @Override
-    public void run(DataManager dataManager, ModuleManager moduleManager, Ui ui, RecipeManager recipeManager)
+    public void run(DataManager dataManager, ModuleManager moduleManager, Ui ui, RecipeManager recipeManager,
+            Storage storage)
             throws CommandException, RecipeManagerException {
         if (recipeName.isBlank()) {
             throw new CommandException(ErrorMessages.MISSING_RECIPE_NAME);

--- a/src/main/java/decodex/recipes/RecipeManager.java
+++ b/src/main/java/decodex/recipes/RecipeManager.java
@@ -1,6 +1,5 @@
 package decodex.recipes;
 
-import decodex.storage.Storage;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -32,15 +31,12 @@ public class RecipeManager {
      */
     private String editingRecipeName;
 
-    private Storage storage;
-
     /**
      * Creates a new RecipeManager with no recipes.
      */
-    public RecipeManager(Storage storage) {
+    public RecipeManager() {
         recipeList = new HashMap<>();
         editingRecipeName = null;
-        this.storage = storage;
     }
 
     /**
@@ -61,13 +57,12 @@ public class RecipeManager {
      * @param recipe The recipe to be added to the recipe manager.
      * @throws RecipeManagerException If the given recipe name already exists in recipe manager.
      */
-    public void addRecipe(Recipe recipe) throws RecipeManagerException, IOException {
+    public void addRecipe(Recipe recipe) throws RecipeManagerException {
         if (recipeList.containsKey(recipe.getName())) {
             throw new RecipeManagerException(ErrorMessages.DUPLICATE_RECIPE_NAME_MESSAGE);
         }
         recipeList.put(recipe.getName(), recipe);
         logger.fine(String.format("[RecipeManager] Added recipe %s", recipe.getName()));
-        storage.saveRecipeToFile(recipe);
     }
 
     /**
@@ -77,14 +72,13 @@ public class RecipeManager {
      * @return The recipe that was removed.
      * @throws RecipeManagerException If the recipe could not be found in the recipe manager.
      */
-    public Recipe removeRecipe(String name) throws RecipeManagerException, IOException {
+    public Recipe removeRecipe(String name) throws RecipeManagerException {
         Recipe recipeToRemove = getRecipe(name);
         recipeList.remove(name);
         if (editingRecipeName != null && editingRecipeName.equals(name)) {
             editingRecipeName = null;
         }
         logger.fine(String.format("[RecipeManager] Removed recipe %s", recipeToRemove.getName()));
-        storage.deleteRecipeFile(name);
         return recipeToRemove;
     }
 
@@ -136,10 +130,9 @@ public class RecipeManager {
      * @param module The module to be added to the recipe.
      * @throws RecipeManagerException If no recipe is selected as currently being edited.
      */
-    public void pushModuleIntoEditedRecipe(Module module) throws RecipeManagerException, IOException {
+    public void pushModuleIntoEditedRecipe(Module module) throws RecipeManagerException {
         Recipe editingRecipe = getEditingRecipe();
         editingRecipe.push(module);
-        storage.saveRecipeToFile(editingRecipe);
     }
 
     /**
@@ -148,10 +141,9 @@ public class RecipeManager {
      * @return The module that was popped from the recipe.
      * @throws RecipeManagerException If no recipe is selected as currently being edited.
      */
-    public Module popModuleFromEditedRecipe() throws RecipeManagerException, RecipeException, IOException {
+    public Module popModuleFromEditedRecipe() throws RecipeManagerException, RecipeException {
         Recipe editingRecipe = getEditingRecipe();
         Module module = editingRecipe.pop();
-        storage.saveRecipeToFile(editingRecipe);
         return module;
     }
 
@@ -160,10 +152,9 @@ public class RecipeManager {
      *
      * @throws RecipeManagerException If no recipe is selected as currently being edited.
      */
-    public void resetEditedRecipe() throws RecipeManagerException, IOException {
+    public void resetEditedRecipe() throws RecipeManagerException {
         Recipe editingRecipe = getEditingRecipe();
         editingRecipe.reset();
-        storage.saveRecipeToFile(editingRecipe);
     }
     // @@author
 }

--- a/src/test/java/decodex/commands/HelpCommandTest.java
+++ b/src/test/java/decodex/commands/HelpCommandTest.java
@@ -24,7 +24,7 @@ class HelpCommandTest {
     private final DataManager dataManager = new DataManager();
     private final ModuleManager moduleManager = new ModuleManager();
     private final Storage storage = new Storage();
-    private final RecipeManager recipeManager = new RecipeManager(storage);
+    private final RecipeManager recipeManager = new RecipeManager();
     private final Ui ui = new Ui();
 
     @BeforeEach
@@ -41,7 +41,7 @@ class HelpCommandTest {
     @Test
     public void run_allCommands_success() {
         HelpCommand command = new HelpCommand();
-        command.run(dataManager, moduleManager, ui, recipeManager);
+        command.run(dataManager, moduleManager, ui, recipeManager, storage);
         assertFalse(outputStream.toString().isBlank());
     }
 }

--- a/src/test/java/decodex/commands/InputCommandTest.java
+++ b/src/test/java/decodex/commands/InputCommandTest.java
@@ -24,11 +24,12 @@ public class InputCommandTest {
         DataManager dataManager = new DataManager();
         ModuleManager moduleManager = new ModuleManager();
         Storage storage = new Storage();
-        RecipeManager recipeManager = new RecipeManager(storage);
+        RecipeManager recipeManager = new RecipeManager();
         Ui ui = new Ui();
         String dataString = "";
         InputCommand testCommand = new InputCommand(dataString);
-        assertThrows(CommandException.class, () -> testCommand.run(dataManager, moduleManager, ui, recipeManager));
+        assertThrows(CommandException.class, () -> testCommand.run(dataManager, moduleManager, ui, recipeManager,
+                storage));
     }
 
     @Test
@@ -37,11 +38,11 @@ public class InputCommandTest {
         DataManager dataManager = new DataManager();
         ModuleManager moduleManager = new ModuleManager();
         Storage storage = new Storage();
-        RecipeManager recipeManager = new RecipeManager(storage);
+        RecipeManager recipeManager = new RecipeManager();
         Ui ui = new Ui();
         String dataString = "something";
         InputCommand testCommand = new InputCommand(dataString);
-        testCommand.run(dataManager, moduleManager, ui, recipeManager);
+        testCommand.run(dataManager, moduleManager, ui, recipeManager, storage);
         Data testData = new Data(dataString);
         assertTrue(Arrays.equals(dataManager.getOriginalData().getRawBytes(), testData.getRawBytes()));
     }

--- a/src/test/java/decodex/commands/ListCommandTest.java
+++ b/src/test/java/decodex/commands/ListCommandTest.java
@@ -25,7 +25,7 @@ public class ListCommandTest {
     private final DataManager dataManager = new DataManager();
     private final ModuleManager moduleManager = new ModuleManager();
     private final Storage storage = new Storage();
-    private final RecipeManager recipeManager = new RecipeManager(storage);
+    private final RecipeManager recipeManager = new RecipeManager();
     private final Ui ui = new Ui();
 
     @BeforeEach
@@ -43,7 +43,7 @@ public class ListCommandTest {
     public void run_listNull_success() throws CommandException {
         String listCategory = null;
         ListCommand listCommand = new ListCommand(listCategory);
-        listCommand.run(dataManager, moduleManager, ui, recipeManager);
+        listCommand.run(dataManager, moduleManager, ui, recipeManager, storage);
         assertFalse(outputStream.toString().isBlank());
     }
 
@@ -51,7 +51,7 @@ public class ListCommandTest {
     public void run_listModules_success() throws CommandException {
         String listCategory = "modules";
         ListCommand listCommand = new ListCommand(listCategory);
-        listCommand.run(dataManager, moduleManager, ui, recipeManager);
+        listCommand.run(dataManager, moduleManager, ui, recipeManager, storage);
         assertFalse(outputStream.toString().isBlank());
     }
 
@@ -59,7 +59,7 @@ public class ListCommandTest {
     public void run_listRecipes_success() throws CommandException {
         String listCategory = "recipes";
         ListCommand listCommand = new ListCommand(listCategory);
-        listCommand.run(dataManager, moduleManager, ui, recipeManager);
+        listCommand.run(dataManager, moduleManager, ui, recipeManager, storage);
         assertFalse(outputStream.toString().isBlank());
     }
 
@@ -67,6 +67,7 @@ public class ListCommandTest {
     public void run_listUnknown_throwsCommandException() {
         String listCategory = "unknown";
         ListCommand listCommand = new ListCommand(listCategory);
-        assertThrows(CommandException.class, () -> listCommand.run(dataManager, moduleManager, ui, recipeManager));
+        assertThrows(CommandException.class, () -> listCommand.run(dataManager, moduleManager, ui, recipeManager,
+                storage));
     }
 }

--- a/src/test/java/decodex/commands/RecipeDeleteCommandTest.java
+++ b/src/test/java/decodex/commands/RecipeDeleteCommandTest.java
@@ -29,12 +29,12 @@ class RecipeDeleteCommandTest {
         ModuleManager moduleManager = new ModuleManager();
         Ui ui = new Ui();
         Storage storage = new Storage();
-        RecipeManager recipeManager = new RecipeManager(storage);
+        RecipeManager recipeManager = new RecipeManager();
 
         recipeManager.addRecipe(new Recipe(testRecipeName));
 
         Command recipeDeleteCommand = new RecipeDeleteCommand(testRecipeName);
-        recipeDeleteCommand.run(dataManager, moduleManager, ui, recipeManager);
+        recipeDeleteCommand.run(dataManager, moduleManager, ui, recipeManager, storage);
 
         assertThrows(RecipeManagerException.class, () -> recipeManager.getRecipe(testRecipeName));
     }
@@ -45,7 +45,7 @@ class RecipeDeleteCommandTest {
         ModuleManager moduleManager = new ModuleManager();
         Ui ui = new Ui();
         Storage storage = new Storage();
-        RecipeManager recipeManager = new RecipeManager(storage);
+        RecipeManager recipeManager = new RecipeManager();
 
         recipeManager.addRecipe(new Recipe("BaconPancakes"));
 
@@ -53,6 +53,6 @@ class RecipeDeleteCommandTest {
         Command recipeDeleteCommand = new RecipeDeleteCommand(testRecipeName);
 
         assertThrows(RecipeManagerException.class,
-            () -> recipeDeleteCommand.run(dataManager, moduleManager, ui, recipeManager));
+            () -> recipeDeleteCommand.run(dataManager, moduleManager, ui, recipeManager, storage));
     }
 }

--- a/src/test/java/decodex/commands/RecipeListCommandTest.java
+++ b/src/test/java/decodex/commands/RecipeListCommandTest.java
@@ -35,7 +35,7 @@ class RecipeListCommandTest {
     private final DataManager dataManager = new DataManager();
     private final ModuleManager moduleManager = new ModuleManager();
     private final Storage storage = new Storage();
-    private final RecipeManager recipeManager = new RecipeManager(storage);
+    private final RecipeManager recipeManager = new RecipeManager();
     private final Ui ui = new Ui();
 
     @BeforeEach
@@ -64,7 +64,7 @@ class RecipeListCommandTest {
     @Test
     void run_listRecipeName_success() throws RecipeManagerException, CommandException, ModuleException {
         RecipeListCommand testCommand = new RecipeListCommand(TEST_RECIPE_NAME);
-        testCommand.run(dataManager, moduleManager, ui, recipeManager);
+        testCommand.run(dataManager, moduleManager, ui, recipeManager, storage);
         assertFalse(outputStream.toString().isBlank());
     }
 
@@ -72,14 +72,14 @@ class RecipeListCommandTest {
     void run_listBlankNoEditingRecipe_expectException() {
         RecipeListCommand testCommand = new RecipeListCommand("");
         assertThrows(RecipeManagerException.class,
-            () -> testCommand.run(dataManager, moduleManager, ui, recipeManager));
+            () -> testCommand.run(dataManager, moduleManager, ui, recipeManager, storage));
     }
 
     @Test
     void run_listBlankHasEditingRecipe_success() throws RecipeManagerException, CommandException, ModuleException {
         recipeManager.selectRecipeForEditing(TEST_RECIPE_NAME);
         RecipeListCommand testCommand = new RecipeListCommand("");
-        testCommand.run(dataManager, moduleManager, ui, recipeManager);
+        testCommand.run(dataManager, moduleManager, ui, recipeManager, storage);
         assertFalse(outputStream.toString().isBlank());
     }
 
@@ -87,14 +87,14 @@ class RecipeListCommandTest {
     void run_listUnknownRecipe_expectException() {
         RecipeListCommand testCommand = new RecipeListCommand("unknownRecipe");
         assertThrows(RecipeManagerException.class,
-            () -> testCommand.run(dataManager, moduleManager, ui, recipeManager));
+            () -> testCommand.run(dataManager, moduleManager, ui, recipeManager, storage));
     }
 
     @Test
     void run_listEmptyRecipe_expectException() throws RecipeManagerException, CommandException, ModuleException {
         recipeManager.getRecipe(TEST_RECIPE_NAME).reset();
         RecipeListCommand testCommand = new RecipeListCommand(TEST_RECIPE_NAME);
-        testCommand.run(dataManager, moduleManager, ui, recipeManager);
+        testCommand.run(dataManager, moduleManager, ui, recipeManager, storage);
         assertFalse(outputStream.toString().isBlank());
     }
 }

--- a/src/test/java/decodex/commands/RecipeNewCommandTest.java
+++ b/src/test/java/decodex/commands/RecipeNewCommandTest.java
@@ -30,9 +30,9 @@ class RecipeNewCommandTest {
         ModuleManager moduleManager = new ModuleManager();
         Ui ui = new Ui();
         Storage storage = new Storage();
-        RecipeManager recipeManager = new RecipeManager(storage);
+        RecipeManager recipeManager = new RecipeManager();
 
-        newRecipeCommand.run(dataManager, moduleManager, ui, recipeManager);
+        newRecipeCommand.run(dataManager, moduleManager, ui, recipeManager, storage);
 
         assertNotNull(recipeManager.getRecipe("BaconPancakes"));
     }
@@ -46,9 +46,9 @@ class RecipeNewCommandTest {
         ModuleManager moduleManager = new ModuleManager();
         Ui ui = new Ui();
         Storage storage = new Storage();
-        RecipeManager recipeManager = new RecipeManager(storage);
+        RecipeManager recipeManager = new RecipeManager();
 
         assertThrows(CommandException.class,
-            () -> newRecipeCommand.run(dataManager, moduleManager, ui, recipeManager));
+            () -> newRecipeCommand.run(dataManager, moduleManager, ui, recipeManager, storage));
     }
 }

--- a/src/test/java/decodex/commands/RecipePopCommandTest.java
+++ b/src/test/java/decodex/commands/RecipePopCommandTest.java
@@ -24,8 +24,7 @@ class RecipePopCommandTest {
     @Test
     public void run_oneModuleToEditingRecipe_recipeSizeIsZero()
             throws RecipeManagerException, ModuleManagerException, ModuleException, RecipeException, IOException {
-        Storage storage = new Storage();
-        RecipeManager recipeManager = new RecipeManager(storage);
+        RecipeManager recipeManager = new RecipeManager();
         String testRecipeName = "test";
         Recipe testRecipe = new Recipe(testRecipeName);
         recipeManager.addRecipe(testRecipe);
@@ -40,7 +39,8 @@ class RecipePopCommandTest {
         RecipePopCommand testCommand = new RecipePopCommand();
         DataManager dataManager = new DataManager();
         Ui ui = new Ui();
-        testCommand.run(dataManager, moduleManager, ui, recipeManager);
+        Storage storage = new Storage();
+        testCommand.run(dataManager, moduleManager, ui, recipeManager, storage);
 
         assertEquals(recipeManager.getEditingRecipe().getModuleList().size(), 0);
     }
@@ -49,17 +49,15 @@ class RecipePopCommandTest {
     public void run_emptyEditingRecipe_expectException() throws RecipeException, RecipeManagerException, IOException {
         DataManager dataManager = new DataManager();
         ModuleManager moduleManager = new ModuleManager();
-        Storage storage = new Storage();
-        RecipeManager recipeManager = new RecipeManager(storage);
+        RecipeManager recipeManager = new RecipeManager();
         Ui ui = new Ui();
-
+        Storage storage = new Storage();
         String testRecipeName = "test";
         Recipe testRecipe = new Recipe(testRecipeName);
         recipeManager.addRecipe(testRecipe);
         recipeManager.selectRecipeForEditing(testRecipeName);
-
         RecipePopCommand testCommand = new RecipePopCommand();
-
-        assertThrows(RecipeException.class, () -> testCommand.run(dataManager, moduleManager, ui, recipeManager));
+        assertThrows(RecipeException.class, () -> testCommand.run(dataManager, moduleManager, ui, recipeManager,
+                storage));
     }
 }

--- a/src/test/java/decodex/commands/RecipePushCommandTest.java
+++ b/src/test/java/decodex/commands/RecipePushCommandTest.java
@@ -28,7 +28,7 @@ class RecipePushCommandTest {
         DataManager dataManager = new DataManager();
         ModuleManager moduleManager = new ModuleManager();
         Storage storage = new Storage();
-        RecipeManager recipeManager = new RecipeManager(storage);
+        RecipeManager recipeManager = new RecipeManager();
         Ui ui = new Ui();
 
         String testRecipeName = "test";
@@ -40,7 +40,7 @@ class RecipePushCommandTest {
         String[] parameters = {};
 
         RecipePushCommand testCommand = new RecipePushCommand(moduleName, parameters);
-        testCommand.run(dataManager, moduleManager, ui, recipeManager);
+        testCommand.run(dataManager, moduleManager, ui, recipeManager, storage);
 
         assertEquals(recipeManager.getEditingRecipe().getModuleList().size(), 1);
     }
@@ -50,7 +50,7 @@ class RecipePushCommandTest {
         DataManager dataManager = new DataManager();
         ModuleManager moduleManager = new ModuleManager();
         Storage storage = new Storage();
-        RecipeManager recipeManager = new RecipeManager(storage);
+        RecipeManager recipeManager = new RecipeManager();
         Ui ui = new Ui();
 
         String testRecipeName = "test";
@@ -63,6 +63,7 @@ class RecipePushCommandTest {
 
         RecipePushCommand testCommand = new RecipePushCommand(moduleName, parameters);
 
-        assertThrows(CommandException.class, () -> testCommand.run(dataManager, moduleManager, ui, recipeManager));
+        assertThrows(CommandException.class, () -> testCommand.run(dataManager, moduleManager, ui, recipeManager,
+                storage));
     }
 }

--- a/src/test/java/decodex/commands/RecipeResetCommandTest.java
+++ b/src/test/java/decodex/commands/RecipeResetCommandTest.java
@@ -24,8 +24,7 @@ class RecipeResetCommandTest {
     @Test
     public void run_oneModuleInEditingRecipe_recipeSizeIsZero() throws RecipeException, RecipeManagerException,
             ModuleManagerException, ModuleException, IOException {
-        Storage storage = new Storage();
-        RecipeManager recipeManager = new RecipeManager(storage);
+        RecipeManager recipeManager = new RecipeManager();
         String testRecipeName = "test";
         Recipe testRecipe = new Recipe(testRecipeName);
         recipeManager.addRecipe(testRecipe);
@@ -40,7 +39,8 @@ class RecipeResetCommandTest {
         RecipeResetCommand testCommand = new RecipeResetCommand();
         DataManager dataManager = new DataManager();
         Ui ui = new Ui();
-        testCommand.run(dataManager, moduleManager, ui, recipeManager);
+        Storage storage = new Storage();
+        testCommand.run(dataManager, moduleManager, ui, recipeManager, storage);
 
         assertEquals(recipeManager.getEditingRecipe().getModuleList().size(), 0);
     }

--- a/src/test/java/decodex/commands/RecipeSelectCommandTest.java
+++ b/src/test/java/decodex/commands/RecipeSelectCommandTest.java
@@ -26,7 +26,7 @@ class RecipeSelectCommandTest {
         DataManager dataManager = new DataManager();
         ModuleManager moduleManager = new ModuleManager();
         Storage storage = new Storage();
-        RecipeManager recipeManager = new RecipeManager(storage);
+        RecipeManager recipeManager = new RecipeManager();
         Ui ui = new Ui();
 
         String testRecipeName = "test";
@@ -34,7 +34,7 @@ class RecipeSelectCommandTest {
         recipeManager.addRecipe(testRecipe);
 
         RecipeSelectCommand testCommand = new RecipeSelectCommand(testRecipeName);
-        testCommand.run(dataManager, moduleManager, ui, recipeManager);
+        testCommand.run(dataManager, moduleManager, ui, recipeManager, storage);
         assertEquals(recipeManager.getEditingRecipe().getName(), testRecipeName);
     }
 
@@ -43,14 +43,14 @@ class RecipeSelectCommandTest {
         DataManager dataManager = new DataManager();
         ModuleManager moduleManager = new ModuleManager();
         Storage storage = new Storage();
-        RecipeManager recipeManager = new RecipeManager(storage);
+        RecipeManager recipeManager = new RecipeManager();
         Ui ui = new Ui();
 
         String testRecipeName = "test";
 
         RecipeSelectCommand testCommand = new RecipeSelectCommand(testRecipeName);
         assertThrows(RecipeManagerException.class,
-            () -> testCommand.run(dataManager, moduleManager, ui, recipeManager));
+            () -> testCommand.run(dataManager, moduleManager, ui, recipeManager, storage));
     }
 
     @Test
@@ -58,13 +58,13 @@ class RecipeSelectCommandTest {
         DataManager dataManager = new DataManager();
         ModuleManager moduleManager = new ModuleManager();
         Storage storage = new Storage();
-        RecipeManager recipeManager = new RecipeManager(storage);
+        RecipeManager recipeManager = new RecipeManager();
         Ui ui = new Ui();
 
         String testRecipeName = "";
 
         RecipeSelectCommand testCommand = new RecipeSelectCommand(testRecipeName);
         assertThrows(CommandException.class,
-            () -> testCommand.run(dataManager, moduleManager, ui, recipeManager));
+            () -> testCommand.run(dataManager, moduleManager, ui, recipeManager, storage));
     }
 }

--- a/src/test/java/decodex/commands/ResetCommandTest.java
+++ b/src/test/java/decodex/commands/ResetCommandTest.java
@@ -23,14 +23,14 @@ class ResetCommandTest {
         DataManager dataManager = new DataManager();
         ModuleManager moduleManager = new ModuleManager();
         Storage storage = new Storage();
-        RecipeManager recipeManager = new RecipeManager(storage);
+        RecipeManager recipeManager = new RecipeManager();
         Ui ui = new Ui();
 
         Data originalData = new Data("hi");
         dataManager.setOriginalData(originalData);
 
         ResetCommand testCommand = new ResetCommand();
-        testCommand.run(dataManager, moduleManager, ui, recipeManager);
+        testCommand.run(dataManager, moduleManager, ui, recipeManager, storage);
         assertTrue(Arrays.equals(dataManager.getCurrentData().getRawBytes(), originalData.getRawBytes()));
     }
 
@@ -39,7 +39,7 @@ class ResetCommandTest {
         DataManager dataManager = new DataManager();
         ModuleManager moduleManager = new ModuleManager();
         Storage storage = new Storage();
-        RecipeManager recipeManager = new RecipeManager(storage);
+        RecipeManager recipeManager = new RecipeManager();
         Ui ui = new Ui();
 
         Data originalData = new Data("hi");
@@ -48,7 +48,7 @@ class ResetCommandTest {
         dataManager.setCurrentData(newData);
 
         ResetCommand testCommand = new ResetCommand();
-        testCommand.run(dataManager, moduleManager, ui, recipeManager);
+        testCommand.run(dataManager, moduleManager, ui, recipeManager, storage);
         assertTrue(Arrays.equals(dataManager.getCurrentData().getRawBytes(), originalData.getRawBytes()));
     }
 }

--- a/src/test/java/decodex/commands/SelectCommandTest.java
+++ b/src/test/java/decodex/commands/SelectCommandTest.java
@@ -29,7 +29,7 @@ public class SelectCommandTest {
         DataManager dataManager = new DataManager();
         ModuleManager moduleManager = new ModuleManager();
         Storage storage = new Storage();
-        RecipeManager recipeManager = new RecipeManager(storage);
+        RecipeManager recipeManager = new RecipeManager();
         Ui ui = new Ui();
 
         Data data = new Data("hello world");
@@ -39,7 +39,7 @@ public class SelectCommandTest {
         String moduleName = "base64encode";
         String[] parameters = {};
         SelectCommand selectCommand = new SelectCommand(selectCategory, moduleName, parameters);
-        selectCommand.run(dataManager, moduleManager, ui, recipeManager);
+        selectCommand.run(dataManager, moduleManager, ui, recipeManager, storage);
 
         assertEquals("aGVsbG8gd29ybGQ=", dataManager.getCurrentData().toString());
     }
@@ -51,7 +51,7 @@ public class SelectCommandTest {
         ModuleManager moduleManager = new ModuleManager();
         Ui ui = new Ui();
         Storage storage = new Storage();
-        RecipeManager recipeManager = new RecipeManager(storage);
+        RecipeManager recipeManager = new RecipeManager();
 
         Data data = new Data("hello world");
         dataManager.setOriginalData(data);
@@ -60,7 +60,7 @@ public class SelectCommandTest {
         String moduleName = "rotencode";
         String[] parameters = {"13"};
         SelectCommand selectCommand = new SelectCommand(selectCategory, moduleName, parameters);
-        selectCommand.run(dataManager, moduleManager, ui, recipeManager);
+        selectCommand.run(dataManager, moduleManager, ui, recipeManager, storage);
 
         assertEquals("uryyb jbeyq", dataManager.getCurrentData().toString());
     }
@@ -70,7 +70,7 @@ public class SelectCommandTest {
         DataManager dataManager = new DataManager();
         ModuleManager moduleManager = new ModuleManager();
         Storage storage = new Storage();
-        RecipeManager recipeManager = new RecipeManager(storage);
+        RecipeManager recipeManager = new RecipeManager();
         Ui ui = new Ui();
 
         Data data = new Data("hello world");
@@ -81,7 +81,8 @@ public class SelectCommandTest {
         String[] parameters = {};
         SelectCommand selectCommand = new SelectCommand(selectCategory, moduleName, parameters);
 
-        assertThrows(CommandException.class, () -> selectCommand.run(dataManager, moduleManager, ui, recipeManager));
+        assertThrows(CommandException.class, () -> selectCommand.run(dataManager, moduleManager, ui, recipeManager,
+                storage));
     }
 
     @Test
@@ -89,7 +90,7 @@ public class SelectCommandTest {
         DataManager dataManager = new DataManager();
         ModuleManager moduleManager = new ModuleManager();
         Storage storage = new Storage();
-        RecipeManager recipeManager = new RecipeManager(storage);
+        RecipeManager recipeManager = new RecipeManager();
         Ui ui = new Ui();
 
         Data data = new Data("hello world");
@@ -101,7 +102,7 @@ public class SelectCommandTest {
         SelectCommand selectCommand = new SelectCommand(selectCategory, moduleName, parameters);
 
         assertThrows(ModuleManagerException.class, () -> selectCommand.run(dataManager, moduleManager, ui,
-                recipeManager));
+                recipeManager, storage));
     }
 
     @Test
@@ -111,8 +112,7 @@ public class SelectCommandTest {
         Data data = new Data("hello world");
         dataManager.setOriginalData(data);
 
-        Storage storage = new Storage();
-        RecipeManager recipeManager = new RecipeManager(storage);
+        RecipeManager recipeManager = new RecipeManager();
         String recipeName = "testRecipe";
         Recipe recipe = new Recipe(recipeName);
         recipe.push(new HexEncoder());
@@ -121,11 +121,12 @@ public class SelectCommandTest {
 
         ModuleManager moduleManager = new ModuleManager();
         Ui ui = new Ui();
+        Storage storage = new Storage();
 
         String selectCategory = "recipe";
         String[] parameters = {};
         SelectCommand selectCommand = new SelectCommand(selectCategory, recipeName, parameters);
-        selectCommand.run(dataManager, moduleManager, ui, recipeManager);
+        selectCommand.run(dataManager, moduleManager, ui, recipeManager, storage);
 
         assertEquals("Njg2NTZjNmM2ZjIwNzc2ZjcyNmM2NA==", dataManager.getCurrentData().toString());
     }
@@ -139,7 +140,7 @@ public class SelectCommandTest {
         dataManager.setOriginalData(data);
 
         Storage storage = new Storage();
-        RecipeManager recipeManager = new RecipeManager(storage);
+        RecipeManager recipeManager = new RecipeManager();
         String recipeName = "testRecipe";
         Recipe recipe = new Recipe(recipeName);
         recipeManager.addRecipe(recipe);
@@ -150,7 +151,7 @@ public class SelectCommandTest {
         String selectCategory = "recipe";
         String[] parameters = {};
         SelectCommand selectCommand = new SelectCommand(selectCategory, recipeName, parameters);
-        selectCommand.run(dataManager, moduleManager, ui, recipeManager);
+        selectCommand.run(dataManager, moduleManager, ui, recipeManager, storage);
 
         assertEquals(dataString, dataManager.getCurrentData().toString());
     }
@@ -160,7 +161,7 @@ public class SelectCommandTest {
         DataManager dataManager = new DataManager();
         ModuleManager moduleManager = new ModuleManager();
         Storage storage = new Storage();
-        RecipeManager recipeManager = new RecipeManager(storage);
+        RecipeManager recipeManager = new RecipeManager();
         Ui ui = new Ui();
 
         String selectCategory = "recipe";
@@ -169,7 +170,7 @@ public class SelectCommandTest {
         SelectCommand selectCommand = new SelectCommand(selectCategory, recipeName, parameters);
 
         assertThrows(RecipeManagerException.class, () -> selectCommand.run(dataManager, moduleManager, ui,
-                recipeManager));
+                recipeManager, storage));
     }
 
     @Test
@@ -177,7 +178,7 @@ public class SelectCommandTest {
         DataManager dataManager = new DataManager();
         ModuleManager moduleManager = new ModuleManager();
         Storage storage = new Storage();
-        RecipeManager recipeManager = new RecipeManager(storage);
+        RecipeManager recipeManager = new RecipeManager();
         Ui ui = new Ui();
 
         String selectCategory = "recipe";
@@ -186,7 +187,7 @@ public class SelectCommandTest {
         SelectCommand selectCommand = new SelectCommand(selectCategory, recipeName, parameters);
 
         assertThrows(RecipeManagerException.class, () -> selectCommand.run(dataManager, moduleManager, ui,
-                recipeManager));
+                recipeManager, storage));
     }
 
     @Test
@@ -194,7 +195,7 @@ public class SelectCommandTest {
         DataManager dataManager = new DataManager();
         ModuleManager moduleManager = new ModuleManager();
         Storage storage = new Storage();
-        RecipeManager recipeManager = new RecipeManager(storage);
+        RecipeManager recipeManager = new RecipeManager();
         Ui ui = new Ui();
 
         String selectCategory = "unknownCategory";
@@ -202,6 +203,7 @@ public class SelectCommandTest {
         String[] parameters = {};
         SelectCommand selectCommand = new SelectCommand(selectCategory, recipeName, parameters);
 
-        assertThrows(CommandException.class, () -> selectCommand.run(dataManager, moduleManager, ui, recipeManager));
+        assertThrows(CommandException.class, () -> selectCommand.run(dataManager, moduleManager, ui, recipeManager,
+                storage));
     }
 }

--- a/src/test/java/decodex/recipes/RecipeManagerTest.java
+++ b/src/test/java/decodex/recipes/RecipeManagerTest.java
@@ -15,12 +15,11 @@ import org.junit.jupiter.api.Test;
 // @@author rizemon
 class RecipeManagerTest {
 
-    private final Storage storage = new Storage();
     private RecipeManager recipeManager;
 
     @BeforeEach
     public void createNewRecipeManager() {
-        recipeManager = new RecipeManager(storage);
+        recipeManager = new RecipeManager();
     }
 
     @Test


### PR DESCRIPTION
* Remove Storage from RecipeManager constructor
* Move Storage method calls in RecipeManager to Command level
* Add Storage to Command run method
* Add try-catch to Commands to deal with IO errors from Storage method calls

The main reason why Storage calls are moved to the Command level is so that during Recipe*Commands,  even if the Storage calls face IO errors, the normal message (like recipe added, recipe deleted etc) will still get printed.

Fixes #249 